### PR TITLE
Throws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+#development environment
+.calva/
+.clj-kondo/
+.cpcache/
+.nrepl-*
+.lsp/

--- a/src/com/mjdowney/rich_comment_tests.clj
+++ b/src/com/mjdowney/rich_comment_tests.clj
@@ -102,7 +102,7 @@
 (defn result-comment?
   "A string like \";=> _\" or \";=>> _\" or \";; => _\""
   [s]
-  (re-matches #"\s*;+\s?=>{1,2}.*\n" s))
+  (re-matches #"\s*;+\s?\S*?=>{1,2}.*\n" s))
 
 (defn pairs
   "Transducer from [a b c ... z] => [[a b] [b c] ... [z nil]]."
@@ -186,13 +186,13 @@
                    ; strip leading ;s from comments
                    (map #(string/replace-first % #"^\s*;+\s?" "")))
                  nodes-following-assertion)]
-      (let [[_ _ fst-line] (re-matches #"(?s)(=>{1,2})(.+)" fst-line)
+      (let [[_ _ fst-line] (re-matches #"(?s)(\S*?=>{1,2})(.+)" fst-line)
             s (string/trim (apply str fst-line rest))]
         (when (seq s)
           s)))))
 
 (defn result-comment-type [z]
-  (let [[_ t _] (re-matches #"(?s);+\s*(=>{1,2})(.+)" (z/string z))]
+  (let [[_ t _] (re-matches #"(?s);+\s*(\S*=>{1,2})(.+)" (z/string z))]
     (symbol t)))
 
 (defn expectation-data

--- a/src/com/mjdowney/rich_comment_tests/emit_tests.clj
+++ b/src/com/mjdowney/rich_comment_tests/emit_tests.clj
@@ -168,7 +168,7 @@
              -do-report# clojure.test/do-report
              dr# (fn [m#] (-do-report# (assoc m# :line ~line :file ~fname)))]
          (with-redefs [clojure.test/do-report dr#]
-           (m/assert ~expectation-form form-result#))))))
+           (m/assert form-result# ~expectation-form))))))
 
 (defn- ex-dispatch
   [expectation-form]


### PR DESCRIPTION
1. Implements `throws=>,` which can check if an exception is thrown.
2. Changes the order of the arguments in the `=>>`; now `actual`, and `expected` will be shown correctly.