### PR TITLE
fix: Fix issue with `require-file-for-ns`

### DIFF
--- a/src/com/mjdowney/rich_comment_tests.clj
+++ b/src/com/mjdowney/rich_comment_tests.clj
@@ -199,12 +199,25 @@
                                           vals
                                           (keep (comp :file meta))
                                           first)]
-      (let [nsf (io/file ns-file-from-metadata)]
+      ;; Yet another hack: Sometimes the path taken from meta is not a full path.
+      ;; If so, process it as a resource and resolve the full path that way.
+      (let [full-path (if (string/starts-with? ns-file-from-metadata (System/getProperty "user.home"))
+                        ns-file-from-metadata
+                        (io/resource ns-file-from-metadata))
+            nsf (io/file full-path)]
         (when (.isFile nsf)
           (.getPath nsf))))
     (throw
       (ex-info (str "Failed to resolve source file for ns " ns)
                {:ns ns}))))
+
+^:rct/test
+(comment
+ (require-file-for-ns *ns*) ;=> string?
+ (require-file-for-ns 'com.mjdowney.rich-comment-tests) ;=> string?
+ (require 'com.mjdowney.rich-comment-tests.impl)
+ (require-file-for-ns 'com.mjdowney.rich-comment-tests.impl) ;=> string?
+ #_:rct/test)
 
 (defn run-ns-tests!
   "Take a namespace or namespace symbol, attempt to find the corresponding


### PR DESCRIPTION
I found out that for some namespace symbols the require-file-for-ns doesn't work.
The file path received from ns meta is not absolute, but relative to the src directory.
Therefore io/file could not resolve the file (isFile false).

```
(require-file-for-ns 'chargedup.stations-api-authorizer.handler)
Execution error (ExceptionInfo) at com.mjdowney.rich-comment-tests/require-file-for-ns (rich_comment_tests.clj:206).
Failed to resolve source file for ns chargedup.stations-api-authorizer.handler
```