### PR TITLE
fix(rct): handle reader conditionals

### DIFF
--- a/src/com/mjdowney/rich_comment_tests/emit_tests.clj
+++ b/src/com/mjdowney/rich_comment_tests/emit_tests.clj
@@ -68,7 +68,7 @@
   [{:keys [expectation-string] :as data}]
   (if expectation-string
     (try
-      (read-string expectation-string)
+      (read-string {:read-cond :allow} expectation-string)
       (catch Exception _
         (throw-bad-expectation-string data)))
     :none))

--- a/src/com/mjdowney/rich_comment_tests/impl.clj
+++ b/src/com/mjdowney/rich_comment_tests/impl.clj
@@ -22,19 +22,6 @@
          (when-some [nxt (f x)]
            (iterate1 f nxt)))))
 
-(defn test-sexpr-zlocs
-  "All sexpr-able nodes inside a rct form."
-  [rct-zloc]
-  (->>
-   (iterate1
-    z/right
-    (-> rct-zloc
-        z/down
-        z/right
-        z/down
-        z/right))
-   (filter z/sexpr-able?)))
-
 (defn pairs
   "Transducer from [a b c ... z] => [[a b] [b c] ... [z nil]]."
   []
@@ -72,6 +59,36 @@
 
   (defn expectation-str [fst-line]
     (-> (re-matches ptn-expectation fst-line) second)))
+
+(defn- follows-empty-result-comment?
+  "True if `zloc` directly follows (through whitespace) an empty result comment
+  like `;=>` or `;=>>`. Such nodes are separate-line expectations, not test
+  expressions."
+  [zloc]
+  (loop [z (z/left* zloc)]
+    (cond
+      (nil? z) false
+      (z/whitespace? z) (recur (z/left* z))
+      :else (let [s (z/string z)]
+              (and (= (z/tag z) :comment)
+                   (result-comment? s)
+                   (let [exp (expectation-str
+                              (string/replace-first s #"^\s*;+\s?" ""))]
+                     (or (nil? exp) (empty? (string/trim exp)))))))))
+
+(defn test-sexpr-zlocs
+  "All sexpr-able nodes inside a rct form."
+  [rct-zloc]
+  (->>
+   (iterate1
+    z/right
+    (-> rct-zloc
+        z/down
+        z/right
+        z/down
+        z/right))
+   (filter z/sexpr-able?)
+   (remove follows-empty-result-comment?)))
 
 ^:rct/test
 (comment

--- a/test/com/mjdowney/rich_comment_tests_test.clj
+++ b/test/com/mjdowney/rich_comment_tests_test.clj
@@ -1,6 +1,6 @@
 (ns com.mjdowney.rich-comment-tests-test
   (:require [clojure.string :as string]
-            [clojure.test :refer [deftest]]
+            [clojure.test :refer [deftest is]]
             [com.mjdowney.rich-comment-tests :as rct]
             [com.mjdowney.rich-comment-tests.test-runner :as test-runner]
             [matcho.core :as m]
@@ -80,3 +80,42 @@
         (println x)         nil
         (dissoc x :a)       {:b 2}}
       strs)))
+
+(defn test-sexprs
+  "Extract just the test sexprs from a comment body string."
+  [comment-body]
+  (let [form (str "^:rct/test\n(comment\n" comment-body "\n)")]
+    (->> (z/of-string form {:track-position? true})
+         rct/rct-zlocs
+         (mapcat rct/rct-data-seq)
+         (mapv :test-sexpr))))
+
+(deftest multiline-expectation-not-treated-as-test-sexpr
+  ;; When ;=> appears on its own line, the following form is the expected value,
+  ;; NOT a test expression. Verifies the follows-empty-result-comment? filter.
+  (let [sexprs (test-sexprs
+                "(update {} :a inc)
+                  ;=>
+                  {:a 1}
+
+                  (+ 1 1) ;=> 2")]
+    (is (= ['(update {} :a inc) '(+ 1 1)] sexprs)
+        "Multi-line expectation value should not appear as a test sexpr")))
+
+(defn rctstr
+  "Run an RCT string through the test pipeline and capture output."
+  [s]
+  (rct/capture-clojure-test-out
+   (rct/run-tests*
+    (z/of-string
+     (str "^:rct/test\n (comment\n" s "\n)")
+     {:track-position? true}))))
+
+(deftest reader-conditional-in-expectation
+  ;; read-string with {:read-cond :allow} should handle reader conditionals
+  ;; in expectation strings (the ;=> side)
+  (let [result (rctstr "(+ 1 0) ;=> #?(:clj 1 :cljs 2)")]
+    (is (not (string/includes? result "FAIL"))
+        "Reader conditional in expectation should pass")
+    (is (not (string/includes? result "ERROR"))
+        "Reader conditional in expectation should not error")))


### PR DESCRIPTION
# Support `#?` reader conditionals in test expectations

## Problem

RCT expectations containing reader conditionals (`#?(:clj ... :cljr ...)`) fail with `Conditional read not allowed`. This affects `.cljc` projects that need platform-specific expected values.

```clojure
;; This fails:
(my-fn args)
;=>
{:result #?(:clj 1 :cljr 2)}
```

There are two independent issues:

### Issue 1: `default-read-expectation` uses `read-string` without `:read-cond`

[`default-read-expectation`](https://github.com/robertluo/rich-comment-tests/blob/c7d044f/src/com/mjdowney/rich_comment_tests/emit_tests.clj#L71) calls `(read-string expectation-string)`, which throws on `#?`.

**Fix:** `(read-string {:read-cond :allow} expectation-string)`

This affects both inline (`;=> #?(:clj 1 :cljr 2)`) and separate-line expectations.

### Issue 2: Separate-line expectations are evaluated as standalone test expressions

[`test-sexpr-zlocs`](https://github.com/robertluo/rich-comment-tests/blob/c7d044f/src/com/mjdowney/rich_comment_tests/impl.clj#L25-L36) returns **all** `z/sexpr-able?` nodes inside a `^:rct/test (comment ...)` block, including forms that serve as separate-line expectations:

```clojure
(+ 1 1)
;=>
2  ;; ← this is ALSO picked up as a standalone test expression
```

For normal values this is harmless (`(eval 2)` → 2). But rewrite-clj's `ReaderMacroNode.sexpr*` converts `#?(:clj x :cljr y)` into the form `(read-string "#?(:clj x :cljr y)")`, and evaluating this calls `clojure.core/read-string` without `:read-cond :allow` → error.

**Fix:** Filter out nodes that directly follow an empty result comment — they are expectations, not test expressions. The actual assertion still runs via `expectation-data` (which traverses forward from the test expression).